### PR TITLE
docs: expand package readmes

### DIFF
--- a/carousel/README.md
+++ b/carousel/README.md
@@ -1,2 +1,39 @@
-# carousel
+# @jeremiemeunier/carousel
+
+Simple React carousel to scroll through an array of slides.
+
+## Installation
+
+Create a `.npmrc` file at the root of your project so npm can access the GitHub registry:
+
+```npmrc
+@jeremiemeunier:registry=https://npm.pkg.github.com
+```
+
+Then install the package:
+
+```bash
+npm install @jeremiemeunier/carousel
+```
+
+## Usage
+
+```tsx
+import { Carousel } from "@jeremiemeunier/carousel";
+
+const slides = [<div>Slide 1</div>, <div>Slide 2</div>, <div>Slide 3</div>];
+
+<Carousel slides={slides} slidesNumber={2} />;
+```
+
+### Props
+
+| Name          | Type                | Default | Description                         |
+| ------------- | ------------------- | :-----: | ----------------------------------- |
+| `slides`      | `React.ReactNode[]` |   —     | Elements to display.                |
+| `slidesNumber`| `number`            |   `4`   | Number of slides visible at a time. |
+| `className`   | `string`            |   —     | Additional CSS classes.             |
+
+`Carousel` scrolls smoothly between groups of slides and renders navigation buttons to move between pages.
+
  

--- a/cursor/README.md
+++ b/cursor/README.md
@@ -1,6 +1,20 @@
-# Cursor
+# @jeremiemeunier/cursor
 
 Custom cursor component that highlights links by drawing a frame around them.
+
+## Installation
+
+Create a `.npmrc` file at the root of your project so npm can access the GitHub registry:
+
+```npmrc
+@jeremiemeunier:registry=https://npm.pkg.github.com
+```
+
+Then install the package:
+
+```bash
+npm install @jeremiemeunier/cursor
+```
 
 ## Usage
 
@@ -16,3 +30,14 @@ export default function App() {
   );
 }
 ```
+
+### Build
+
+If you clone this repository and want to generate the distributable files run:
+
+```bash
+npm run build
+```
+
+This uses **tsup** to compile the source into the `dist/` folder.
+

--- a/drawer/README.md
+++ b/drawer/README.md
@@ -1,2 +1,51 @@
-# drawer
+# @jeremiemeunier/drawer
+
+Slide-in side panel with a React context and hook.
+
+## Installation
+
+Create a `.npmrc` file at the root of your project so npm can access the GitHub registry:
+
+```npmrc
+@jeremiemeunier:registry=https://npm.pkg.github.com
+```
+
+Then install the package:
+
+```bash
+npm install @jeremiemeunier/drawer
+```
+
+## Usage
+
+Wrap your application with the `DrawerProvider` and control the drawer through the `useDrawer` hook:
+
+```tsx
+import { DrawerProvider, useDrawer } from "@jeremiemeunier/drawer";
+
+const App = () => {
+  const { openDrawer, pushContent } = useDrawer();
+
+  return (
+    <DrawerProvider>
+      <button
+        onClick={() => {
+          pushContent(<div>My drawer content</div>);
+          openDrawer();
+        }}
+      >
+        Open drawer
+      </button>
+    </DrawerProvider>
+  );
+};
+```
+
+### API
+
+- `DrawerProvider` – context provider wrapping your app.
+- `useDrawer()` – hook returning `pushContent`, `openDrawer`, `closeDrawer`, and `switchDrawer` functions.
+
+The drawer uses **framer-motion** for animations and **simplebar-react** for scrollbars.
+
  

--- a/navigation/README.md
+++ b/navigation/README.md
@@ -1,17 +1,48 @@
 # @jeremiemeunier/navigation
 
-To add `@jeremiemeunier` to you project you need to create a `.npmrc` file at the same folder base of you `package.json` with this line :
+Helpers for managing navigation state and pagination in React apps.
+
+## Installation
+
+Create a `.npmrc` file at the root of your project so npm can access the GitHub registry:
 
 ```npmrc
 @jeremiemeunier:registry=https://npm.pkg.github.com
 ```
 
-## Package
+Then install the package:
 
-`@jeremiemeunier/navigation` provide to you 2 element and 1 hook with 2 functions :
+```bash
+npm install @jeremiemeunier/navigation
+```
 
-- provider: `<NavigationProvider>`
+## Usage
+
+Wrap your application with the `NavigationProvider` to expose navigation state:
 
 ```tsx
-<NavigationProvider>{/* Some other things of your apps */}</NavigationProvider>
+import { NavigationProvider, NavigationContext } from "@jeremiemeunier/navigation";
+
+<NavigationProvider>{/* your app */}</NavigationProvider>;
 ```
+
+Access and update the context with React's `useContext`:
+
+```tsx
+const { appActualPage, setAppActualPage } = useContext(NavigationContext);
+```
+
+### Pagination component
+
+The package also includes a `Pagination` component to switch between pages:
+
+```tsx
+import { Pagination } from "@jeremiemeunier/navigation";
+
+const [page, setPage] = useState(1);
+
+<Pagination pages={10} page={page} setPage={setPage} />;
+```
+
+`Pagination` accepts an optional `sticky` prop to keep the component fixed while scrolling.
+


### PR DESCRIPTION
## Summary
- document installation and usage for carousel component
- add provider and hook usage to drawer docs
- enrich cursor and navigation package readmes

## Testing
- `npm test` (carousel) *(fails: Missing script "test")*
- `npm test` (drawer) *(fails: Missing script "test")*
- `npm test` (cursor) *(fails: Missing script "test")*
- `npm test` (navigation) *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a5f4d176cc8324892be576af6425a2